### PR TITLE
story/553 Better Error handling when deserialisation fails in Reports

### DIFF
--- a/src/main/java/com/regnosys/rosetta/common/reports/RegReportUseCase.java
+++ b/src/main/java/com/regnosys/rosetta/common/reports/RegReportUseCase.java
@@ -17,6 +17,7 @@ public class RegReportUseCase {
 	private final String useCaseReportJavaClassName;
 	private final ExpectedResult expectedResults;
 	private final RosettaModelObject input;
+	private final String error;
 
 	@JsonCreator
 	public RegReportUseCase(@JsonProperty("useCase") String useCase,
@@ -25,7 +26,8 @@ public class RegReportUseCase {
 							@JsonProperty("useCaseReport") RosettaModelObject useCaseReport,
 							@JsonProperty("useCaseReportJavaClassName") String useCaseReportJavaClassName,
 							@JsonProperty("expectedResults") ExpectedResult expectedResults,
-							@JsonProperty("input") RosettaModelObject input) {
+							@JsonProperty("input") RosettaModelObject input,
+							@JsonProperty("error") String error) {
 		this.useCase = useCase;
 		this.dataSetName = dataSetName;
 		this.results = results;
@@ -33,6 +35,7 @@ public class RegReportUseCase {
 		this.useCaseReportJavaClassName = useCaseReportJavaClassName;
 		this.expectedResults = expectedResults;
 		this.input = input;
+		this.error = error;
 	}
 
 	public RegReportUseCase(RegReportUseCase other) {
@@ -43,6 +46,7 @@ public class RegReportUseCase {
 		this.useCaseReportJavaClassName = other.useCaseReportJavaClassName;
 		this.expectedResults = other.expectedResults;
 		this.input = other.input;
+		this.error = other.error;
 	}
 
 	public String getUseCase() {
@@ -73,17 +77,24 @@ public class RegReportUseCase {
 		return input;
 	}
 
+	public String getError(){ return error; }
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		RegReportUseCase that = (RegReportUseCase) o;
-		return Objects.equals(getUseCase(), that.getUseCase()) && Objects.equals(getDataSetName(), that.getDataSetName()) && Objects.equals(getResults(), that.getResults()) && Objects.equals(getUseCaseReport(), that.getUseCaseReport()) && Objects.equals(getUseCaseReportJavaClassName(), that.getUseCaseReportJavaClassName()) && Objects.equals(getExpectedResults(), that.getExpectedResults()) && Objects.equals(getInput(), that.getInput());
+		return Objects.equals(getUseCase(), that.getUseCase()) && Objects.equals(getDataSetName(), that.getDataSetName())
+				&& Objects.equals(getResults(), that.getResults()) && Objects.equals(getUseCaseReport(), that.getUseCaseReport())
+				&& Objects.equals(getUseCaseReportJavaClassName(), that.getUseCaseReportJavaClassName())
+				&& Objects.equals(getExpectedResults(), that.getExpectedResults())
+				&& Objects.equals(getInput(), that.getInput())
+				&& Objects.equals(getError(), that.getError());
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(getUseCase(), getDataSetName(), getResults(), getUseCaseReport(), getUseCaseReportJavaClassName(), getExpectedResults(), getInput());
+		return Objects.hash(getUseCase(), getDataSetName(), getResults(), getUseCaseReport(), getUseCaseReportJavaClassName(), getExpectedResults(), getInput(), getError());
 	}
 
 	@Override
@@ -96,6 +107,7 @@ public class RegReportUseCase {
 				.add("useCaseReportJavaClassName='" + useCaseReportJavaClassName + "'")
 				.add("expectedResults=" + expectedResults)
 				.add("input=" + input)
+				.add("error=" + error)
 				.toString();
 	}
 }

--- a/src/main/java/com/regnosys/rosetta/common/reports/RegReportUseCase.java
+++ b/src/main/java/com/regnosys/rosetta/common/reports/RegReportUseCase.java
@@ -17,7 +17,7 @@ public class RegReportUseCase {
 	private final String useCaseReportJavaClassName;
 	private final ExpectedResult expectedResults;
 	private final RosettaModelObject input;
-	private final String error;
+	private final Exception error;
 
 	@JsonCreator
 	public RegReportUseCase(@JsonProperty("useCase") String useCase,
@@ -27,7 +27,7 @@ public class RegReportUseCase {
 							@JsonProperty("useCaseReportJavaClassName") String useCaseReportJavaClassName,
 							@JsonProperty("expectedResults") ExpectedResult expectedResults,
 							@JsonProperty("input") RosettaModelObject input,
-							@JsonProperty("error") String error) {
+							@JsonProperty("error") Exception error) {
 		this.useCase = useCase;
 		this.dataSetName = dataSetName;
 		this.results = results;
@@ -77,7 +77,7 @@ public class RegReportUseCase {
 		return input;
 	}
 
-	public String getError(){ return error; }
+	public Exception getError(){ return error; }
 
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/com/regnosys/rosetta/common/serialisation/reportdata/JsonReportDataLoader.java
+++ b/src/main/java/com/regnosys/rosetta/common/serialisation/reportdata/JsonReportDataLoader.java
@@ -37,12 +37,15 @@ public class JsonReportDataLoader extends AbstractJsonDataLoader<ReportDataSet> 
     public ReportDataSet loadInputFiles(ReportDataSet descriptor) {
         List<ReportDataItem> loadedData = new ArrayList<>();
         for (ReportDataItem data : descriptor.getData()) {
-            ReportDataItem reportDataItem = new ReportDataItem(data.getName(),
-                    getInput(descriptor.getInputType(), data),
-                    data.getExpected()); // expected is handled by JsonExpectedResultLoader
+            ReportDataItem reportDataItem;
+            try {
+                reportDataItem = new ReportDataItem(data.getName(), getInput(descriptor.getInputType(), data),
+                        data.getExpected()); // expected is handled by JsonExpectedResultLoader
+            } catch (RuntimeException e) {
+                reportDataItem = new ReportDataItem(data.getName(), data.getInput(), data.getExpected(), e);
+            }
             loadedData.add(reportDataItem);
         }
-
         return new ReportDataSet(descriptor.getDataSetName(), descriptor.getInputType(), descriptor.getApplicableReports(), loadedData);
     }
 

--- a/src/main/java/com/regnosys/rosetta/common/serialisation/reportdata/ReportDataItem.java
+++ b/src/main/java/com/regnosys/rosetta/common/serialisation/reportdata/ReportDataItem.java
@@ -44,11 +44,8 @@ public class ReportDataItem {
     }
 
     @JsonIgnore
-    public String getError() {
-        if(error != null)
-            return error.getMessage();
-        else
-            return null;
+    public Exception getError() {
+        return error;
     }
 
     @Override

--- a/src/main/java/com/regnosys/rosetta/common/serialisation/reportdata/ReportDataItem.java
+++ b/src/main/java/com/regnosys/rosetta/common/serialisation/reportdata/ReportDataItem.java
@@ -1,5 +1,8 @@
 package com.regnosys.rosetta.common.serialisation.reportdata;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+
 import java.util.*;
 
 public class ReportDataItem {
@@ -7,14 +10,21 @@ public class ReportDataItem {
     private String name;
     private Object input;
     private Object expected;
+    @JsonIgnore
+    private Exception error;
+
 
     public ReportDataItem() {
     }
 
     public ReportDataItem(String name, Object input, Object expected) {
+        this(name, input, expected, null);
+    }
+    public ReportDataItem(String name, Object input, Object expected, Exception error) {
         this.name = name;
         this.input = input;
         this.expected = expected;
+        this.error = error;
     }
 
     public String getName() {
@@ -22,11 +32,21 @@ public class ReportDataItem {
     }
 
     public Object getInput() {
+        if(error != null){
+            Exceptions.sneakyThrow(error);
+        }
         return input;
     }
 
     public Object getExpected() {
         return expected;
+    }
+
+    public String getError() {
+        if(error != null)
+            return error.getLocalizedMessage();
+        else
+            return null;
     }
 
     @Override

--- a/src/main/java/com/regnosys/rosetta/common/serialisation/reportdata/ReportDataItem.java
+++ b/src/main/java/com/regnosys/rosetta/common/serialisation/reportdata/ReportDataItem.java
@@ -10,6 +10,7 @@ public class ReportDataItem {
     private String name;
     private Object input;
     private Object expected;
+
     @JsonIgnore
     private Exception error;
 
@@ -42,9 +43,10 @@ public class ReportDataItem {
         return expected;
     }
 
+    @JsonIgnore
     public String getError() {
         if(error != null)
-            return error.getLocalizedMessage();
+            return (error).getLocalizedMessage();
         else
             return null;
     }

--- a/src/main/java/com/regnosys/rosetta/common/serialisation/reportdata/ReportDataItem.java
+++ b/src/main/java/com/regnosys/rosetta/common/serialisation/reportdata/ReportDataItem.java
@@ -46,7 +46,7 @@ public class ReportDataItem {
     @JsonIgnore
     public String getError() {
         if(error != null)
-            return (error).getLocalizedMessage();
+            return error.getMessage();
         else
             return null;
     }

--- a/src/test/java/com/regnosys/rosetta/common/serialisation/reportdata/JsonReportDataLoaderTest.java
+++ b/src/test/java/com/regnosys/rosetta/common/serialisation/reportdata/JsonReportDataLoaderTest.java
@@ -12,8 +12,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class JsonReportDataLoaderTest {
 
@@ -64,6 +64,32 @@ class JsonReportDataLoaderTest {
         List<ReportDataSet> reportDataSets = loadReportDataSets(path, path);
 
         assertEquals(reportDataSets.size(), 0);
+    }
+
+    @Test
+    void lookupsLoadedWithError() throws MalformedURLException {
+        // descriptor and input on same path
+        Path path = RESOURCES_PATH.resolve("regs/test-use-case-load-error");
+
+        List<ReportDataSet> reportDataSets = loadReportDataSets(path, path);
+
+        assertEquals(reportDataSets.size(), 1);
+        assertEquals(reportDataSets.get(0).getData().size(), 2);
+
+        assertNull(reportDataSets.get(0).getData().get(0).getError());
+        assertNull(reportDataSets.get(0).getData().get(1).getError());
+
+        assertTrue(reportDataSets.get(0).getData().get(0).getInput() instanceof EventTestModelObject);
+        assertTrue(reportDataSets.get(0).getData().get(1).getInput() instanceof EventTestModelObject);
+
+        assertEquals(new ReportDataItem("This is the desc of the usecase",
+                        new EventTestModelObject(LocalDate.parse("2018-02-20"), "NewTrade"),
+                        null),
+                reportDataSets.get(0).getData().get(0));
+        assertEquals(new ReportDataItem("This is the desc of the another usecase that has inline json rather then a file",
+                        new EventTestModelObject(LocalDate.parse("2018-02-21"), "TerminatedTrade"),
+                        null),
+                reportDataSets.get(0).getData().get(1));
     }
 
     private List<ReportDataSet> loadReportDataSets(Path descriptorPath, Path inputPath) throws MalformedURLException {

--- a/src/test/java/com/regnosys/rosetta/common/serialisation/reportdata/JsonReportDataLoaderTest.java
+++ b/src/test/java/com/regnosys/rosetta/common/serialisation/reportdata/JsonReportDataLoaderTest.java
@@ -67,7 +67,7 @@ class JsonReportDataLoaderTest {
     }
 
     @Test
-    void lookupsLoadedWithError() throws MalformedURLException {
+    void lookupsLoadedWithAllErrors() throws MalformedURLException {
         // descriptor and input on same path
         Path path = RESOURCES_PATH.resolve("regs/test-use-case-load-error");
 
@@ -76,20 +76,33 @@ class JsonReportDataLoaderTest {
         assertEquals(reportDataSets.size(), 1);
         assertEquals(reportDataSets.get(0).getData().size(), 2);
 
+        assertNotNull(reportDataSets.get(0).getData().get(0).getError());
+        assertNotNull(reportDataSets.get(0).getData().get(1).getError());
+
+        assertThrows(RuntimeException.class, () -> reportDataSets.get(0).getData().get(0).getInput());
+        assertThrows(RuntimeException.class, () -> reportDataSets.get(0).getData().get(1).getInput());
+    }
+    @Test
+    void lookupsLoadedWithOneError() throws MalformedURLException {
+        // descriptor and input on same path
+        Path path = RESOURCES_PATH.resolve("regs/test-use-case-load-one-error");
+
+        List<ReportDataSet> reportDataSets = loadReportDataSets(path, path);
+
+        assertEquals(reportDataSets.size(), 1);
+        assertEquals(reportDataSets.get(0).getData().size(), 2);
+
         assertNull(reportDataSets.get(0).getData().get(0).getError());
-        assertNull(reportDataSets.get(0).getData().get(1).getError());
+        assertNotNull(reportDataSets.get(0).getData().get(1).getError());
+
+        assertThrows(RuntimeException.class, () -> reportDataSets.get(0).getData().get(1).getInput());
 
         assertTrue(reportDataSets.get(0).getData().get(0).getInput() instanceof EventTestModelObject);
-        assertTrue(reportDataSets.get(0).getData().get(1).getInput() instanceof EventTestModelObject);
-
         assertEquals(new ReportDataItem("This is the desc of the usecase",
                         new EventTestModelObject(LocalDate.parse("2018-02-20"), "NewTrade"),
                         null),
                 reportDataSets.get(0).getData().get(0));
-        assertEquals(new ReportDataItem("This is the desc of the another usecase that has inline json rather then a file",
-                        new EventTestModelObject(LocalDate.parse("2018-02-21"), "TerminatedTrade"),
-                        null),
-                reportDataSets.get(0).getData().get(1));
+
     }
 
     private List<ReportDataSet> loadReportDataSets(Path descriptorPath, Path inputPath) throws MalformedURLException {

--- a/src/test/resources/regs/test-use-case-load-error/regulatory-reporting-data-descriptor.json
+++ b/src/test/resources/regs/test-use-case-load-error/regulatory-reporting-data-descriptor.json
@@ -1,0 +1,22 @@
+[
+  {
+    "dataSetName": "Test set 1",
+    "inputType": "com.regnosys.rosetta.common.serialisation.reportdata.JsonReportDataLoaderTest$EventTestModelObject",
+    "applicableReports": [],
+    "data": [
+      {
+        "name": "This is the desc of the usecase",
+        "input": "test1.json",
+        "error": "Null pointer exception"
+      },
+      {
+        "name": "This is the desc of the another usecase that has inline json rather then a file",
+        "input": {
+          "eventDate": "2018-02-21",
+          "eventQualifier": "TerminatedTrade"
+        },
+        "error": "some other exception"
+      }
+    ]
+  }
+]

--- a/src/test/resources/regs/test-use-case-load-error/test1.json
+++ b/src/test/resources/regs/test-use-case-load-error/test1.json
@@ -1,0 +1,4 @@
+{
+  "eventDate" : "2018-02-20",
+  "eventQualifier" : "NewTrade"
+}

--- a/src/test/resources/regs/test-use-case-load-one-error/regulatory-reporting-data-descriptor.json
+++ b/src/test/resources/regs/test-use-case-load-one-error/regulatory-reporting-data-descriptor.json
@@ -11,7 +11,7 @@
       {
         "name": "This is the desc of the another usecase that has inline json rather then a file",
         "input": {
-          "eventDate": "invalid",
+          "eventDate": "error",
           "eventQualifier": "TerminatedTrade"
         }
       }

--- a/src/test/resources/regs/test-use-case-load-one-error/test1.json
+++ b/src/test/resources/regs/test-use-case-load-one-error/test1.json
@@ -1,4 +1,4 @@
 {
-  "eventDate" : "error",
+  "eventDate" : "2018-02-20",
   "eventQualifier" : "NewTrade"
 }


### PR DESCRIPTION
Reports should be able to work as expected even if one of the individual ones are corrupt because of a model change.

As part of this change, when a report fails deserialisation, the errored report is displayed to the user as a red highlighted row and the other valid reports are also displayed.